### PR TITLE
Fix whitespace on bottom for tall screens

### DIFF
--- a/src/app/contactUs/page.tsx
+++ b/src/app/contactUs/page.tsx
@@ -26,7 +26,7 @@ export default function ContactUs() {
           });
       `}
       </Script>
-    <div className="bg-slate-200 dark:bg-black md:min-h-[88vh] lg:min-h-[74vh] ">
+    <div className="bg-slate-200 dark:bg-black h-full">
         <div id="all content" className="w-screen flex flex-col items-center">
           <div id="header" className="bg-[url('/images/contact/contact.jpg')] w-screen flex justify-center items-center h-48">
             <h1 className={`text-white font-bold border-8 p-4 m-16 text-5xl md:text-7xl text-center ${play.className}`}>Contact Us </h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="min-w-fit">
-      <body className={open.className}>
+      <body className={`${open.className} min-h-screen flex flex-col`}>
         <Navbar />
-        {children}
+        <div className="grow bg-slate-200 dark:bg-black">
+          {children}
+        </div>
         <Footer/>
       </body>
     </html>


### PR DESCRIPTION
This PR prevents ending white space when the screen is taller than the contents. A wrapper around the content is implemented in the root page, and this wrapper will grow (through `flex-grow`) to fulfill the remaining white space with a dark background. Here is an image of the issue:
![image](https://github.com/scioly-gatech/website/assets/105668049/6c5df4d1-078f-43ac-81fe-883c72a9d682)
