### PR TITLE
Add Netlify config for Vite deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary
- Adds `netlify.toml` with Vite build settings (`npm run build`, publish `dist`)
- Adds SPA redirects so client-side routes work on Netlify

## Why
`sciolygatech.org` is still served from Netlify as the old Next.js site. This config is required for Netlify to build and publish the new Vite site after redeploy.