### PR TITLE
Skip Netlify Next.js plugin for Vite build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[build.environment]
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
- Sets `NETLIFY_NEXT_PLUGIN_SKIP=true` so `@netlify/plugin-nextjs` does not fail Vite builds
- Keeps publish directory as `dist`

## Why
Netlify deploys are failing because the site still has the Next.js plugin enabled from the old stack, even though `npm run build` now outputs Vite assets to `dist/`.